### PR TITLE
Be consistent with solidity merkle tree library used in plasma contracts

### DIFF
--- a/lib/merkle_tree.ex
+++ b/lib/merkle_tree.ex
@@ -56,6 +56,9 @@ defmodule MerkleTree do
 
   # Number of children per node. Configurable.
   @number_of_children 2
+  # values prepended to a leaf and node to differentiate between them when calculating values
+  # of parent in Merkle Tree, added to prevent a second preimage attack
+  # where a proof for node can be validated as a proof for leaf
   @leaf_salt <<0>>
   @node_salt <<1>>
 

--- a/test/merkle_tree/proof_test.exs
+++ b/test/merkle_tree/proof_test.exs
@@ -4,6 +4,8 @@ defmodule MerkleTree.ProofTest do
 
   import MerkleTree.Proof
 
+  @node_salt <<1>>
+
   test "correct proofs" do
     blocks = ~w/a b c d e f g h/
     tree = MerkleTree.new(blocks)
@@ -20,27 +22,10 @@ defmodule MerkleTree.ProofTest do
            |> Enum.all?()
   end
 
-  # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
-  test "correct proofs with deprecated proven?/3" do
-    blocks = ~w/a b c d e f g h/
-    tree = MerkleTree.new(blocks)
-
-    proofs =
-      blocks
-      |> Enum.with_index()
-      |> Enum.map(fn {_, idx} -> prove(tree, idx) end)
-
-    assert blocks
-           |> Enum.with_index()
-           |> Enum.zip(proofs)
-           |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, proof) end)
-           |> Enum.all?()
-  end
-
   test "incorrect proof" do
     blocks = ~w/a b c d e f g h/
     tree = MerkleTree.new(blocks)
-    %MerkleTree.Proof{hashes: hashes} = proof = prove(tree, 5)
+    proof = prove(tree, 5)
 
     # test sanity
     assert proven?({"f", 5}, tree.root.value, tree.hash_function, proof)
@@ -48,77 +33,32 @@ defmodule MerkleTree.ProofTest do
     # bad index
     assert not proven?({"f", 6}, tree.root.value, tree.hash_function, proof)
 
-    incomplete_proof = %MerkleTree.Proof{
-      hashes: tl(hashes),
-      hash_function: tree.hash_function
-    }
-
+    incomplete_proof = tl(proof)
     assert not proven?({"f", 5}, tree.root.value, tree.hash_function, incomplete_proof)
 
     # different hash function
     assert not proven?({"f", 5}, tree.root.value, &MerkleTree.Crypto.hash(&1, :sha224), proof)
 
-    corrupted_proof = %MerkleTree.Proof{
-      hashes: [tree.hash_function.("z")] ++ tl(hashes),
-      hash_function: tree.hash_function
-    }
-
+    corrupted_proof = [tree.hash_function.("z")] ++ tl(proof)
     assert not proven?({"f", 5}, tree.root.value, tree.hash_function, corrupted_proof)
 
     # corrupted root hash
     assert not proven?({"f", 5}, tree.hash_function.("z"), tree.hash_function, proof)
 
     # fake proof rejected with proven?/4
-    fake_proof = %MerkleTree.Proof{
-      hashes: Enum.map(hashes, fn _ -> "" end),
-      hash_function: fn _ -> tree.root.value end
-    }
-
+    fake_proof = Enum.map(proof, fn _ -> "" end)
     assert not proven?({"z", 5}, tree.root.value, tree.hash_function, fake_proof)
   end
 
-  # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
-  test "incorrect proof with deprecated proven?/3" do
-    blocks = ~w/a b c d e f g h/
-    tree = MerkleTree.new(blocks)
-    %MerkleTree.Proof{hashes: hashes} = proof = prove(tree, 5)
+  test "can not prove that node is a leaf" do
+      blocks = ~w/a b c d e f g h/
+      tree = MerkleTree.new(blocks)
 
-    # test sanity
-    assert proven?({"f", 5}, tree.root.value, proof)
+      proof = prove(tree, 0)
+      node_proof = tl(proof)
 
-    # bad index
-    assert not proven?({"f", 6}, tree.root.value, proof)
+      node = tree.hash_function.(@node_salt <> "a" <> "b")
 
-    incomplete_proof = %MerkleTree.Proof{
-      hashes: tl(hashes),
-      hash_function: tree.hash_function
-    }
-
-    assert not proven?({"f", 5}, tree.root.value, incomplete_proof)
-
-    different_hash = %MerkleTree.Proof{
-      hashes: hashes,
-      hash_function: &MerkleTree.Crypto.hash(&1, :sha224)
-    }
-
-    assert not proven?({"f", 5}, tree.root.value, different_hash)
-
-    corrupted_proof = %MerkleTree.Proof{
-      hashes: [tree.hash_function.("z")] ++ tl(hashes),
-      hash_function: tree.hash_function
-    }
-
-    assert not proven?({"f", 5}, tree.root.value, corrupted_proof)
-
-    # corrupted root hash
-    assert not proven?({"f", 5}, tree.hash_function.("z"), proof)
-
-    # fake proof accepted with deprecated proven?/3
-    fake_proof = %MerkleTree.Proof{
-      hashes: Enum.map(hashes, fn _ -> "" end),
-      hash_function: fn _ -> tree.root.value end
-    }
-
-    assert proven?({"z", 5}, tree.root.value, fake_proof)
+      assert not proven?({node, 0}, tree.root.value, tree.hash_function, node_proof)
   end
 end

--- a/test/merkle_tree_test.exs
+++ b/test/merkle_tree_test.exs
@@ -2,6 +2,9 @@ defmodule MerkleTreeTest do
   use ExUnit.Case
   doctest MerkleTree
 
+  @leaf_salt <<0>>
+  @node_salt <<1>>
+
   test "invalid empty blocks" do
     assert_raise(FunctionClauseError, fn -> MerkleTree.new([]) end)
   end
@@ -15,8 +18,8 @@ defmodule MerkleTreeTest do
   end
 
   test "primary use case" do
-    f = MerkleTree.new(['a', 'b', 'c', 'd'])
-    assert f.root.value == "58c89d709329eb37285837b042ab6ff72c7c8f74de0446b091b6a0131c102cfd"
+    f = MerkleTree.new(["a", "b", "c", "d"])
+    assert f.root.value == "9dc1674ae1ee61c90ba50b6261e8f9a47f7ea07d92612158edfe3c2a37c6d74c"
   end
 
   test "ability to calculate tree in varying flavours of the builder functions equivalently" do
@@ -27,50 +30,43 @@ defmodule MerkleTreeTest do
       assert MerkleTree.new(blocks, default_data_block: "").root == MerkleTree.build(blocks)
     end
 
-    [['a', 'b', 'c', 'd'], ['a', 'b', 'c'], ['a', 'b'], ['a'], []]
+    [["a", "b", "c", "d"], ["a", "b", "c"], ["a", "b"], ["a"], []]
     |> Enum.map(assertions)
   end
 
   test "default data block with height" do
-    assert MerkleTree.new(['a', 'a', 'a', 'a']) ==
-             MerkleTree.new([], default_data_block: 'a', height: 2)
+    assert MerkleTree.new(["a", "a", "a", "a"]) ==
+             MerkleTree.new([], default_data_block: "a", height: 2)
   end
 
   test "default data block without height" do
-    assert MerkleTree.new(List.duplicate('a', 8)) ==
-             MerkleTree.new(List.duplicate('a', 5), default_data_block: 'a')
-  end
-
-  test "check hash leaf false" do
-    blocks = ['a', 'a', 'a', 'a']
-
-    assert MerkleTree.new(blocks).root ==
-             MerkleTree.new(blocks |> Enum.map(&MerkleTree.Crypto.sha256/1), hash_leaves: false).root
+    assert MerkleTree.new(List.duplicate("a", 8)) ==
+             MerkleTree.new(List.duplicate("a", 5), default_data_block: "a")
   end
 
   test "default hash function sha256" do
-    blocks = ['a', 'a', 'a', 'a']
+    blocks = ["a", "a", "a", "a"]
     assert MerkleTree.new(blocks, &MerkleTree.Crypto.sha256/1) == MerkleTree.new(blocks)
   end
 
   test "merkle tree node" do
     hash = &MerkleTree.Crypto.sha256/1
 
-    assert MerkleTree.build(['a', 'b'], &MerkleTree.Crypto.sha256/1) == %MerkleTree.Node{
+    assert MerkleTree.build(["a", "b"], &MerkleTree.Crypto.sha256/1) == %MerkleTree.Node{
              children: [
                %MerkleTree.Node{
                  children: [],
                  height: 0,
-                 value: hash.('a')
+                 value: hash.(@leaf_salt <> "a")
                },
                %MerkleTree.Node{
                  children: [],
                  height: 0,
-                 value: hash.('b')
+                 value: hash.(@leaf_salt <> "b")
                }
              ],
              height: 1,
-             value: hash.(hash.('a') <> hash.('b'))
+             value: hash.(@node_salt <> hash.(@leaf_salt <> "a") <> hash.(@leaf_salt <>"b"))
            }
   end
 end

--- a/test/merkle_tree_test.exs
+++ b/test/merkle_tree_test.exs
@@ -52,7 +52,7 @@ defmodule MerkleTreeTest do
   test "merkle tree node" do
     hash = &MerkleTree.Crypto.sha256/1
 
-    assert MerkleTree.build(["a", "b"], &MerkleTree.Crypto.sha256/1) == %MerkleTree.Node{
+    assert MerkleTree.build(["a", "b"], hash) == %MerkleTree.Node{
              children: [
                %MerkleTree.Node{
                  children: [],


### PR DESCRIPTION
- Calculates merkle tree and proofs as in solidity library (solving issue https://github.com/omisego/plasma-contracts/issues/425)
- Adds `0` byte to each leaf before hashing and `1` byte to each node before hashing.
- Removes deprecated `proven?/3` function.